### PR TITLE
RF-5339 Decouple tests from starting mock services

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ machine:
 checkout:
   post:
     - gem install fake_sqs
-    - gem install fakes3
+    - gem install fakes3 -v 0.2.4
     - sudo add-apt-repository ppa:masterminds/glide -y && sudo apt-get update -y
     - sudo apt-get install glide -y
     # And now some hacks because CircleCI's go handling is braindead
@@ -23,6 +23,6 @@ dependencies:
 
 test:
   override:
-    - cd $BUILD; go test -v -race $(glide novendor)
+    - cd $BUILD; ./test.sh
     - cd $BUILD; go tool vet -all *.go
     - cd $BUILD; golint

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+S3DIR=$(mktemp -d)
+
+fakes3 server --port 4569 --root "${S3DIR}" &
+FAKES3_PID="$!"
+
+fake_sqs &
+FAKESQS_PID="$!"
+
+go test -v -race $(glide novendor)
+
+kill -2 ${FAKES3_PID} ${FAKESQS_PID}
+rm -rf "${S3DIR}"


### PR DESCRIPTION
Coupling the tests with starting fake services makes it difficult to
deploy the tests (as it bakes assumptions into how these services are
provided into the provider). So remove that coupling.