### PR TITLE
RF-19899 Use DockerHub user for pulling down images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,24 @@
-version: 2
+version: 2.1
 
 jobs:
   build:
     docker:
       - image: circleci/golang:1.9-stretch-browsers
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
       - image: airdock/fake-sqs:0.3.1
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
       - image: lphoward/fake-s3
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
       - image: circleci/redis:5.0.3-alpine
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
     working_directory: /go/src/github.com/rainforestapp/testutil
     steps:
       - checkout
@@ -24,4 +36,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - build
+      - build:
+          context:
+            - DockerHub


### PR DESCRIPTION
Docker are changing their TOS to rate limit unauthenticated `docker pull`
from the start of November. The rate limiting is based on IP, so builds on
Circle will be immediately impacted. Use a paid-for account and contexts to
configure a user to pull down docker images for CI/CD.
